### PR TITLE
Named server and deprecation changes

### DIFF
--- a/nerscspawner/nerscspawner.py
+++ b/nerscspawner/nerscspawner.py
@@ -230,10 +230,6 @@ which jupyterhub-singleuser
         env = super().get_env()
 
         env.update(dict(
-            JPY_USER=self.user.name,
-            JPY_COOKIE_NAME=self.user.server.cookie_name,
-            JPY_BASE_URL=self.user.server.base_url,
-            JPY_HUB_PREFIX=self.hub.server.base_url,
             JUPYTERHUB_PREFIX=self.hub.server.base_url,
             # PATH=self.path
             # NERSC local mod
@@ -247,7 +243,6 @@ which jupyterhub-singleuser
         if self.hub_api_url != '':
             hub_api_url = self.hub_api_url
 
-        env['JPY_HUB_API_URL'] = hub_api_url
         env['JUPYTERHUB_API_URL'] = hub_api_url
 
         return env


### PR DESCRIPTION
NERSCSlurmSpawner already extends base's `get_env` instead of creating its own, so not all of the changes made in the [corresponding PR for SSHSpawner](https://github.com/krinsman/sshspawner/commit/c0d479bc064e8647f990048ebe0e93088d830809) are necessary. 

That being said (I haven't tested it, so I don't know for certain), I imagine that the attempt to set `JPY_COOKIE_NAME` would be as much of an issue for this spawner when using [the named server implementation](https://github.com/jupyterhub/jupyterhub/pull/2089) as it was for SSHSpawner.

The setting of the other deleted environment variables is made redundant by the fact that the non-deprecated counterparts of the variables [are already set properly in the parent's `get_env` implementation](https://github.com/jupyterhub/jupyterhub/blob/master/jupyterhub/spawner.py#L609), so I removed those lines as well.